### PR TITLE
Fix gpu forl oop bug

### DIFF
--- a/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
+++ b/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
@@ -132,7 +132,7 @@ module queens_GPU_call_device_search{
           var rd: int;
           // Check vertical
           /*for ( i = 0; i < r; ++i)*/
-          for i in 0..<r {
+          for i in 0..<r do
             if (board[i] == board[r]) then safe = false;
             // Check diagonals
             ld = board[r];  //left diagonal columns
@@ -142,7 +142,7 @@ module queens_GPU_call_device_search{
               rd += 1;
               if (board[i] == ld || board[i] == rd) then safe = false;
             }
-          }
+          
 
           return safe;
         }

--- a/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
+++ b/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
@@ -7,7 +7,7 @@ module queens_GPU_call_device_search{
 	//use GPU_aux;
 	use Math;
 	//use CPtr;
-	use DateTime;
+	use Time;
         use GPUDiagnostics;
 
 	config const CPUGPUVerbose: bool = false;

--- a/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
+++ b/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
@@ -8,20 +8,17 @@ module queens_GPU_call_device_search{
 	use Math;
 	//use CPtr;
 	use Time;
-        use GPUDiagnostics;
+  use GPUDiagnostics;
 
 	config const CPUGPUVerbose: bool = false;
 
-
 	proc queens_GPU_call_device_search(const num_gpus: c_int, const size: uint(16), const depthPreFixos: c_int,
-		ref local_active_set: [] queens_node, const initial_num_prefixes: uint(64)): (uint(64), uint(64)){
+		ref local_active_set: [] queens_node, const initial_num_prefixes: uint(64)): (uint(64), uint(64)) {
 
-                startVerboseGPU();
-
+    startVerboseGPU();
 
 		var vector_of_tree_size_h: [0..#initial_num_prefixes] c_ulonglong;
 		var sols_h: [0..#initial_num_prefixes] c_ulonglong;
-
 
 		//calculating the CPU load in terms of nodes
 		var new_num_prefixes: uint(64) = initial_num_prefixes;
@@ -29,122 +26,112 @@ module queens_GPU_call_device_search{
 
 		//@question: should we use forall or coforall?
 
-		for gpu_id in 0..#num_gpus:c_int do{
+		for gpu_id in 0..#num_gpus:c_int do {
+      var gpu_load: c_uint = GPU_mlocale_get_gpu_load(new_num_prefixes:c_uint, gpu_id:c_int, num_gpus);
 
-				var gpu_load: c_uint = GPU_mlocale_get_gpu_load(new_num_prefixes:c_uint, gpu_id:c_int, num_gpus);
+      var starting_position = GPU_mlocale_get_starting_point(new_num_prefixes:c_uint,
+        gpu_id:c_uint, num_gpus:c_uint, 0:c_uint);
 
-				var starting_position = GPU_mlocale_get_starting_point(new_num_prefixes:c_uint,
-					gpu_id:c_uint, num_gpus:c_uint, 0:c_uint);
+      var sol_ptr : c_ptr(c_ulonglong) = c_ptrTo(sols_h) + starting_position;
+      var tree_ptr : c_ptr(c_ulonglong) = c_ptrTo(vector_of_tree_size_h) + starting_position;
+      var nodes_ptr : c_ptr(queens_node) = c_ptrTo(local_active_set) + starting_position;
 
-				var sol_ptr : c_ptr(c_ulonglong) = c_ptrTo(sols_h) + starting_position;
-				var tree_ptr : c_ptr(c_ulonglong) = c_ptrTo(vector_of_tree_size_h) + starting_position;
-				var nodes_ptr : c_ptr(queens_node) = c_ptrTo(local_active_set) + starting_position;
+      if(CPUGPUVerbose) then
+        writeln("GPU id: ", gpu_id, " Starting position: ", starting_position, " gpu load: ", gpu_load);
 
-				if(CPUGPUVerbose) then
-					writeln("GPU id: ", gpu_id, " Starting position: ", starting_position, " gpu load: ", gpu_load);
+        param _EMPTY_ = -1;
 
-                                param _EMPTY_ = -1;
+        on here.gpus[gpu_id] {
 
-                                on here.gpus[gpu_id] {
+          var root_prefixes = local_active_set;
+          var sols: [sols_h.domain] sols_h.eltType;
+          var vector_of_tree_size: [vector_of_tree_size_h.domain] vector_of_tree_size_h.eltType;
 
-                                  var root_prefixes = local_active_set;
-                                  var sols: [sols_h.domain] sols_h.eltType;
-                                  var vector_of_tree_size: [vector_of_tree_size_h.domain] vector_of_tree_size_h.eltType;
+          //writeln("starting loop");
+          foreach idx in 0..#gpu_load {
+            var flag = 0: uint;
+            var bit_test = 0: uint;
+            /*var board: [0..31] int(8);*/
+            var board: c_array(int(8), 32);
 
-                                //  writeln("starting loop");
-                                  foreach idx in 0..#gpu_load {
-                                    var flag = 0: uint;
-                                    var bit_test = 0: uint;
-                                    /*var board: [0..31] int(8);*/
-                                    var board: c_array(int(8), 32);
+            var depth;
 
-                                    var depth;
+            var N_l = size;
+            var qtd_solucoes_thread = 0: uint(64);
+            var depthGlobal = depthPreFixos;
+            var tree_size = 0: uint(64);
 
-                                    var N_l = size;
-                                    var qtd_solucoes_thread = 0: uint(64);
-                                    var depthGlobal = depthPreFixos;
-                                    var tree_size = 0: uint(64);
+            for i in 0..<N_l do  // what happens if I use promotion here?
+              board[i] = _EMPTY_;
 
-                                    for i in 0..<N_l do  // what happens if I use promotion here?
-                                      board[i] = _EMPTY_;
+            flag = root_prefixes[idx:uint(64)].control;
 
-                                    flag = root_prefixes[idx:uint(64)].control;
+            for i in 0..<depthGlobal do
+              board[i] = root_prefixes[idx:uint(64)].board[i];
 
+            depth=depthGlobal;
 
-                                    for i in 0..<depthGlobal do
-                                      board[i] = root_prefixes[idx:uint(64)].board[i];
+            do{
+              board[depth] += 1;
+              bit_test = 0;
+              bit_test |= 1<<board[depth];
 
-                                    depth=depthGlobal;
+              if(board[depth] == N_l){
+                board[depth] = _EMPTY_;
+                //if(block_ub > upper)   block_ub = upper;
+              }else if (!(flag &  bit_test ) && GPU_queens_stillLegal(board, depth)){
 
-                                    do{
+                tree_size += 1;
+                flag |= (1<<board[depth]);
 
-                                      board[depth] += 1;
-                                      bit_test = 0;
-                                      bit_test |= 1<<board[depth];
+                depth += 1;
 
-                                      if(board[depth] == N_l){
-                                        board[depth] = _EMPTY_;
-                                        //if(block_ub > upper)   block_ub = upper;
-                                      }else if (!(flag &  bit_test ) && GPU_queens_stillLegal(board, depth)){
+                if (depth == N_l) { //sol
+                  qtd_solucoes_thread += 1;
+                }else continue;
+              }else continue;
 
-                                        tree_size += 1;
-                                        flag |= (1<<board[depth]);
+              depth -= 1;
+              flag &= ~(1<<board[depth]);
 
-                                        depth += 1;
+            }while(depth >= depthGlobal); //FIM DO DFS_BNB
 
-                                        if (depth == N_l) { //sol
-                                          qtd_solucoes_thread += 1;
-                                        }else continue;
-                                      }else continue;
+            /*writeln("Sols: ", qtd_solucoes_thread);*/
+            sols[idx] = qtd_solucoes_thread;
+            vector_of_tree_size[idx] = tree_size;
+          }
 
-                                      depth -= 1;
-                                      flag &= ~(1<<board[depth]);
+          sols_h = sols;
+          vector_of_tree_size_h = vector_of_tree_size;
+        }
+    }//end of gpu search
 
-                                    }while(depth >= depthGlobal); //FIM DO DFS_BNB
-
-                                    /*writeln("Sols: ", qtd_solucoes_thread);*/
-                                    sols[idx] = qtd_solucoes_thread;
-                                    vector_of_tree_size[idx] = tree_size;
-
-                                  }
-
-                                  sols_h = sols;
-                                  vector_of_tree_size_h = vector_of_tree_size;
-
-                                }
-
-			}//end of gpu search
+    stopVerboseGPU();
 
 		var redTree = (+ reduce vector_of_tree_size_h):uint(64);
 		var redSol  = (+ reduce sols_h):uint(64);
 
-                stopVerboseGPU();
-
 		return ((redSol,redTree)+metrics);
+	}
 
-	}///
+  proc  GPU_queens_stillLegal(board, r) {
+    var safe = true;
+    var i: int;
+    var ld: int;
+    var rd: int;
 
-        proc  GPU_queens_stillLegal(board, r){
+    // Check vertical
+    for i in 0..<r do
+      if (board[i] == board[r]) then safe = false;
 
-          var safe = true;
-          var i: int;
-          var ld: int;
-          var rd: int;
-          // Check vertical
-          /*for ( i = 0; i < r; ++i)*/
-          for i in 0..<r do
-            if (board[i] == board[r]) then safe = false;
-            // Check diagonals
-            ld = board[r];  //left diagonal columns
-            rd = board[r];  // right diagonal columns
-            for i in 0..<r by -1 {
-              ld -= 1;
-              rd += 1;
-              if (board[i] == ld || board[i] == rd) then safe = false;
-            }
-          
-
-          return safe;
-        }
-
+    // Check diagonals
+    ld = board[r];  //left diagonal columns
+    rd = board[r];  // right diagonal columns
+    for i in 0..<r by -1 {
+      ld -= 1;
+      rd += 1;
+      if (board[i] == ld || board[i] == rd) then safe = false;
+    }
+    return safe;
+  }
 }

--- a/other_codes/cudaOnly/singleGPUQueens.cu
+++ b/other_codes/cudaOnly/singleGPUQueens.cu
@@ -74,15 +74,16 @@ __device__  bool GPU_queens_stillLegal(const char *board, const int r){
   // Check vertical
   for ( i = 0; i < r; ++i)
     if (board[i] == board[r]) safe = false;
-    // Check diagonals
-    ld = board[r];  //left diagonal columns
-    rd = board[r];  // right diagonal columns
-    for ( i = r-1; i >= 0; --i) {
-      --ld; ++rd;
-      if (board[i] == ld || board[i] == rd) safe = false;
-    }
 
-    return safe;
+  // Check diagonals
+  ld = board[r];  //left diagonal columns
+  rd = board[r];  // right diagonal columns
+  for ( i = r-1; i >= 0; --i) {
+    --ld; ++rd;
+    if (board[i] == ld || board[i] == rd) safe = false;
+  }
+
+  return safe;
 }
 
 


### PR DESCRIPTION
The main change of this is to fix a bug where we accidentally nested a 'for' loop that should not have been nested.

More specifically, in `GPU_queens_stillLegal` we nested the "check diagonals" step inside the "check vertical" step.  This doesn't lead to a wrong answer but since its redundantly computing the diagonal check it leads to a significant slowdown.

Some other changes: 

* In Chapel 1.28 the `DateTime` module was deprecated and its content was moved into `Time`. I've updated a `use` to this.
* Modified indentation.
