### PR TITLE
Some optimizations for Chapel and CUDA versions of a benchmark

### DIFF
--- a/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
+++ b/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
@@ -59,6 +59,7 @@ module queens_GPU_call_device_search{
             var flag = 0: uint(32);
             var bit_test = 0: uint(32);
             /*var board: [0..31] int(8);*/
+            // alignment didn't help
             var _board: c_array(int(8), 64);
             var board = getAligned(c_ptrTo(_board[0]), 32);
 

--- a/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
+++ b/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
@@ -49,12 +49,12 @@ module queens_GPU_call_device_search{
 
           //writeln("starting loop");
           foreach idx in 0..#gpu_load {
-            var flag = 0: uint;
-            var bit_test = 0: uint;
+            var flag = 0: uint(32);
+            var bit_test = 0: uint(32);
             /*var board: [0..31] int(8);*/
             var board: c_array(int(8), 32);
 
-            var depth;
+            var depth: int(32);
 
             var N_l = size;
             var qtd_solucoes_thread = 0: uint(64);
@@ -64,17 +64,17 @@ module queens_GPU_call_device_search{
             for i in 0..<N_l do  // what happens if I use promotion here?
               board[i] = _EMPTY_;
 
-            flag = root_prefixes[idx:uint(64)].control;
+            flag = root_prefixes[idx].control;
 
             for i in 0..<depthGlobal do
-              board[i] = root_prefixes[idx:uint(64)].board[i];
+              board[i] = root_prefixes[idx].board[i];
 
             depth=depthGlobal;
 
             do{
               board[depth] += 1;
               bit_test = 0;
-              bit_test |= 1<<board[depth];
+              bit_test |= 1:int(32)<<board[depth];
 
               if(board[depth] == N_l){
                 board[depth] = _EMPTY_;
@@ -82,7 +82,7 @@ module queens_GPU_call_device_search{
               }else if (!(flag &  bit_test ) && GPU_queens_stillLegal(board, depth)){
 
                 tree_size += 1;
-                flag |= (1<<board[depth]);
+                flag |= (1:int(32)<<board[depth]);
 
                 depth += 1;
 
@@ -92,7 +92,7 @@ module queens_GPU_call_device_search{
               }else continue;
 
               depth -= 1;
-              flag &= ~(1<<board[depth]);
+              flag &= ~(1:int(32)<<board[depth]);
 
             }while(depth >= depthGlobal); //FIM DO DFS_BNB
 

--- a/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
+++ b/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
@@ -119,8 +119,9 @@ module queens_GPU_call_device_search{
     var safe = true;
     const base = board[r];
     for (i, rev_i, offset) in zip(0..<r, 0..<r by -1, 1..r) {
-      safe &= !((board[i] == base) || (board[rev_i] == base-offset ||
-                                        board[rev_i] == base+offset));
+      // why can't I use bitwise OR for the second case?
+      safe &= !((board[i] == base) | (board[rev_i] == base-offset ||
+                                      board[rev_i] == base+offset));
     }
     return safe;
   }

--- a/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
+++ b/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
@@ -12,13 +12,6 @@ module queens_GPU_call_device_search{
 
 	config const CPUGPUVerbose: bool = false;
 
-        proc getAligned(x: c_ptr, param alignment=32) {
-          var xAsInt = x:int;
-          xAsInt += alignment-(xAsInt%alignment);
-
-          return __primitive("cast", x.type, xAsInt);
-        }
-
 	proc queens_GPU_call_device_search(const num_gpus: c_int, const size: uint(16), const depthPreFixos: c_int,
 		ref local_active_set: [] queens_node, const initial_num_prefixes: uint(64)): (uint(64), uint(64)) {
 
@@ -57,7 +50,7 @@ module queens_GPU_call_device_search{
           //writeln("starting loop");
           foreach idx in 0..#gpu_load {
             var flag = 0: uint(32);
-            // alignment didn't help
+            // alignment doesn't seem to help
             var board: c_array(int(8), 64);
 
             var depth: int(32);
@@ -86,7 +79,7 @@ module queens_GPU_call_device_search{
                 //if(block_ub > upper)   block_ub = upper;
                 depth -= 1;
                 flag &= ~(1:int(32)<<board[depth]);
-              } else if (!(flag &  mask ) && GPU_queens_stillLegal(board, depth)){
+              } else if (!(flag & mask ) && GPU_queens_stillLegal(board, depth)){
 
                 tree_size += 1;
                 flag |= mask;

--- a/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
+++ b/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
@@ -57,10 +57,10 @@ module queens_GPU_call_device_search{
           //writeln("starting loop");
           foreach idx in 0..#gpu_load {
             var flag = 0: uint(32);
-            var bit_test = 0: uint(32);
+            /*var bit_test = 0: uint(32);*/
             /*var board: [0..31] int(8);*/
             // alignment didn't help
-            var board: c_array(int(8), 32);
+            var board: c_array(int(8), 64);
             /*var board = getAligned(c_ptrTo(_board[0]), 32);*/
 
             var depth: int(32);

--- a/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
+++ b/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
@@ -117,8 +117,8 @@ module queens_GPU_call_device_search{
   proc  GPU_queens_stillLegal(board, r) {
     var safe = true;
     var i: int;
-    var ld: int;
-    var rd: int;
+    var ld: int(32);
+    var rd: int(32);
 
     // Check vertical
     for i in 0..<r do

--- a/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
+++ b/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
@@ -57,11 +57,8 @@ module queens_GPU_call_device_search{
           //writeln("starting loop");
           foreach idx in 0..#gpu_load {
             var flag = 0: uint(32);
-            /*var bit_test = 0: uint(32);*/
-            /*var board: [0..31] int(8);*/
             // alignment didn't help
             var board: c_array(int(8), 64);
-            /*var board = getAligned(c_ptrTo(_board[0]), 32);*/
 
             var depth: int(32);
 
@@ -128,7 +125,6 @@ module queens_GPU_call_device_search{
     var safe = true;
     const base = board[r];
     for (i, rev_i, offset) in zip(0..<r, 0..<r by -1, 1..r) {
-      // why can't I use bitwise OR for the second case?
       safe &= !((board[i] == base) | ( (board[rev_i] == base-offset) |
                                        (board[rev_i] == base+offset)));
     }

--- a/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
+++ b/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
@@ -116,21 +116,12 @@ module queens_GPU_call_device_search{
 
   proc  GPU_queens_stillLegal(board, r) {
     var safe = true;
-    var i: int;
-    var ld: int(32);
-    var rd: int(32);
-
-    // Check vertical
-    for i in 0..<r do
-      if (board[i] == board[r]) then safe = false;
-
-    // Check diagonals
-    ld = board[r];  //left diagonal columns
-    rd = board[r];  // right diagonal columns
-    for i in 0..<r by -1 {
-      ld -= 1;
-      rd += 1;
-      if (board[i] == ld || board[i] == rd) then safe = false;
+    const base = board[r];
+    for (i, rev_i, offset) in zip(0..<r, 0..<r by -1, 1..r) {
+      if (board[i] == base) || (board[rev_i] == base-offset ||
+                                board[rev_i] == base+offset) {
+        safe = false;
+      }
     }
     return safe;
   }

--- a/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
+++ b/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
@@ -73,26 +73,27 @@ module queens_GPU_call_device_search{
 
             do{
               board[depth] += 1;
-              bit_test = 0;
-              bit_test |= 1:int(32)<<board[depth];
+              const mask = 1:int(32)<<board[depth];
 
               if(board[depth] == N_l){
                 board[depth] = _EMPTY_;
                 //if(block_ub > upper)   block_ub = upper;
-              }else if (!(flag &  bit_test ) && GPU_queens_stillLegal(board, depth)){
+                depth -= 1;
+                flag &= ~(1:int(32)<<board[depth]);
+              } else if (!(flag &  mask ) && GPU_queens_stillLegal(board, depth)){
 
                 tree_size += 1;
-                flag |= (1:int(32)<<board[depth]);
+                flag |= mask;
 
                 depth += 1;
 
                 if (depth == N_l) { //sol
                   qtd_solucoes_thread += 1;
-                }else continue;
-              }else continue;
 
-              depth -= 1;
-              flag &= ~(1:int(32)<<board[depth]);
+                  depth -= 1;
+                  flag &= ~mask;
+                }
+              }
 
             }while(depth >= depthGlobal); //FIM DO DFS_BNB
 

--- a/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
+++ b/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
@@ -119,10 +119,8 @@ module queens_GPU_call_device_search{
     var safe = true;
     const base = board[r];
     for (i, rev_i, offset) in zip(0..<r, 0..<r by -1, 1..r) {
-      if (board[i] == base) || (board[rev_i] == base-offset ||
-                                board[rev_i] == base+offset) {
-        safe = false;
-      }
+      safe &= !((board[i] == base) || (board[rev_i] == base-offset ||
+                                        board[rev_i] == base+offset));
     }
     return safe;
   }

--- a/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
+++ b/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
@@ -60,8 +60,8 @@ module queens_GPU_call_device_search{
             var bit_test = 0: uint(32);
             /*var board: [0..31] int(8);*/
             // alignment didn't help
-            var _board: c_array(int(8), 64);
-            var board = getAligned(c_ptrTo(_board[0]), 32);
+            var board: c_array(int(8), 32);
+            /*var board = getAligned(c_ptrTo(_board[0]), 32);*/
 
             var depth: int(32);
 
@@ -129,8 +129,8 @@ module queens_GPU_call_device_search{
     const base = board[r];
     for (i, rev_i, offset) in zip(0..<r, 0..<r by -1, 1..r) {
       // why can't I use bitwise OR for the second case?
-      safe &= !((board[i] == base) | (board[rev_i] == base-offset ||
-                                      board[rev_i] == base+offset));
+      safe &= !((board[i] == base) | ( (board[rev_i] == base-offset) |
+                                       (board[rev_i] == base+offset)));
     }
     return safe;
   }

--- a/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
+++ b/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
@@ -12,6 +12,13 @@ module queens_GPU_call_device_search{
 
 	config const CPUGPUVerbose: bool = false;
 
+        proc getAligned(x: c_ptr, param alignment=32) {
+          var xAsInt = x:int;
+          xAsInt += alignment-(xAsInt%alignment);
+
+          return __primitive("cast", x.type, xAsInt);
+        }
+
 	proc queens_GPU_call_device_search(const num_gpus: c_int, const size: uint(16), const depthPreFixos: c_int,
 		ref local_active_set: [] queens_node, const initial_num_prefixes: uint(64)): (uint(64), uint(64)) {
 
@@ -52,7 +59,8 @@ module queens_GPU_call_device_search{
             var flag = 0: uint(32);
             var bit_test = 0: uint(32);
             /*var board: [0..31] int(8);*/
-            var board: c_array(int(8), 32);
+            var _board: c_array(int(8), 64);
+            var board = getAligned(c_ptrTo(_board[0]), 32);
 
             var depth: int(32);
 

--- a/other_codes/cudaOnly/singleGPUQueens.cu
+++ b/other_codes/cudaOnly/singleGPUQueens.cu
@@ -108,8 +108,6 @@ __global__ void BP_queens_root_dfs(int N, unsigned int nPrefixes, int initial_de
 
             board[depth]++;
             const int mask = 1<<board[depth];
-            //bit_test = 0;
-            //bit_test |= (1<<board[depth]);
 
             if(board[depth] == N_l){
                 board[depth] = _EMPTY_;
@@ -130,10 +128,6 @@ __global__ void BP_queens_root_dfs(int N, unsigned int nPrefixes, int initial_de
                         flag &= ~mask;
                     }
                 }
-
-            //depth--;
-            //flag &= ~(1<<board[depth]);
-
             }while(depth >= depthGlobal); //FIM DO DFS_BNB
 
         sols[idx] = qtd_sols_thread ;


### PR DESCRIPTION
This PR has some optimizations to:

- match data types between C and Chapel versions
- fuse innermost loops in an inner function
- make conditionals in the main loop less divergent
- reduce short-circuit branching by using bitwise operation


These changes make Chapel go about 1.7x faster, while it helps C+CUDA by 1.15x. I used Chapel's new profiler support to figure these on Chapel, then ported them back to C.