### PR TITLE
Prepare for 1.30, fix indentation

### DIFF
--- a/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
+++ b/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
@@ -8,14 +8,14 @@ module queens_GPU_call_device_search{
 	use Math;
 	//use CPtr;
 	use Time;
-  use GPUDiagnostics;
+        use GpuDiagnostics;
 
 	config const CPUGPUVerbose: bool = false;
 
 	proc queens_GPU_call_device_search(const num_gpus: c_int, const size: uint(16), const depthPreFixos: c_int,
 		ref local_active_set: [] queens_node, const initial_num_prefixes: uint(64)): (uint(64), uint(64)) {
 
-    startVerboseGPU();
+                startVerboseGpu();
 
 		var vector_of_tree_size_h: [0..#initial_num_prefixes] c_ulonglong;
 		var sols_h: [0..#initial_num_prefixes] c_ulonglong;
@@ -106,7 +106,7 @@ module queens_GPU_call_device_search{
         }
     }//end of gpu search
 
-    stopVerboseGPU();
+    stopVerboseGpu();
 
 		var redTree = (+ reduce vector_of_tree_size_h):uint(64);
 		var redSol  = (+ reduce sols_h):uint(64);

--- a/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
+++ b/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
@@ -1,137 +1,137 @@
 module queens_GPU_call_device_search{
 
-	use queens_tree_exploration;
-	use queens_node_module;
-	use GPU_mlocale_utils;
-	use CTypes;
-	//use GPU_aux;
-	use Math;
-	//use CPtr;
-	use Time;
+        use queens_tree_exploration;
+        use queens_node_module;
+        use GPU_mlocale_utils;
+        use CTypes;
+        //use GPU_aux;
+        use Math;
+        //use CPtr;
+        use Time;
         use GpuDiagnostics;
 
-	config const CPUGPUVerbose: bool = false;
+        config const CPUGPUVerbose: bool = false;
 
-	proc queens_GPU_call_device_search(const num_gpus: c_int, const size: uint(16), const depthPreFixos: c_int,
-		ref local_active_set: [] queens_node, const initial_num_prefixes: uint(64)): (uint(64), uint(64)) {
+        proc queens_GPU_call_device_search(const num_gpus: c_int, const size: uint(16), const depthPreFixos: c_int,
+                                           ref local_active_set: [] queens_node, const initial_num_prefixes: uint(64)): (uint(64), uint(64)) {
 
                 startVerboseGpu();
 
-		var vector_of_tree_size_h: [0..#initial_num_prefixes] c_ulonglong;
-		var sols_h: [0..#initial_num_prefixes] c_ulonglong;
+                var vector_of_tree_size_h: [0..#initial_num_prefixes] c_ulonglong;
+                var sols_h: [0..#initial_num_prefixes] c_ulonglong;
 
-		//calculating the CPU load in terms of nodes
-		var new_num_prefixes: uint(64) = initial_num_prefixes;
-		var metrics: (uint(64),uint(64)) = (0:uint(64),0:uint(64));//
+                //calculating the CPU load in terms of nodes
+                var new_num_prefixes: uint(64) = initial_num_prefixes;
+                var metrics: (uint(64),uint(64)) = (0:uint(64),0:uint(64));//
 
-		//@question: should we use forall or coforall?
+                //@question: should we use forall or coforall?
 
-		for gpu_id in 0..#num_gpus:c_int do {
-      var gpu_load: c_uint = GPU_mlocale_get_gpu_load(new_num_prefixes:c_uint, gpu_id:c_int, num_gpus);
+                for gpu_id in 0..#num_gpus:c_int do {
+                        var gpu_load: c_uint = GPU_mlocale_get_gpu_load(new_num_prefixes:c_uint, gpu_id:c_int, num_gpus);
 
-      var starting_position = GPU_mlocale_get_starting_point(new_num_prefixes:c_uint,
-        gpu_id:c_uint, num_gpus:c_uint, 0:c_uint);
+                        var starting_position = GPU_mlocale_get_starting_point(new_num_prefixes:c_uint,
+                                        gpu_id:c_uint, num_gpus:c_uint, 0:c_uint);
 
-      var sol_ptr : c_ptr(c_ulonglong) = c_ptrTo(sols_h) + starting_position;
-      var tree_ptr : c_ptr(c_ulonglong) = c_ptrTo(vector_of_tree_size_h) + starting_position;
-      var nodes_ptr : c_ptr(queens_node) = c_ptrTo(local_active_set) + starting_position;
+                        var sol_ptr : c_ptr(c_ulonglong) = c_ptrTo(sols_h) + starting_position;
+                        var tree_ptr : c_ptr(c_ulonglong) = c_ptrTo(vector_of_tree_size_h) + starting_position;
+                        var nodes_ptr : c_ptr(queens_node) = c_ptrTo(local_active_set) + starting_position;
 
-      if(CPUGPUVerbose) then
-        writeln("GPU id: ", gpu_id, " Starting position: ", starting_position, " gpu load: ", gpu_load);
+                        if(CPUGPUVerbose) then
+                                writeln("GPU id: ", gpu_id, " Starting position: ", starting_position, " gpu load: ", gpu_load);
 
-        param _EMPTY_ = -1;
+                        param _EMPTY_ = -1;
 
-        on here.gpus[gpu_id] {
+                        on here.gpus[gpu_id] {
 
-          var root_prefixes = local_active_set;
-          var sols: [sols_h.domain] sols_h.eltType;
-          var vector_of_tree_size: [vector_of_tree_size_h.domain] vector_of_tree_size_h.eltType;
+                                var root_prefixes = local_active_set;
+                                var sols: [sols_h.domain] sols_h.eltType;
+                                var vector_of_tree_size: [vector_of_tree_size_h.domain] vector_of_tree_size_h.eltType;
 
-          //writeln("starting loop");
-          foreach idx in 0..#gpu_load {
-            var flag = 0: uint;
-            var bit_test = 0: uint;
-            /*var board: [0..31] int(8);*/
-            var board: c_array(int(8), 32);
+                                //writeln("starting loop");
+                                foreach idx in 0..#gpu_load {
+                                        var flag = 0: uint;
+                                        var bit_test = 0: uint;
+                                        /*var board: [0..31] int(8);*/
+                                        var board: c_array(int(8), 32);
 
-            var depth;
+                                        var depth;
 
-            var N_l = size;
-            var qtd_solucoes_thread = 0: uint(64);
-            var depthGlobal = depthPreFixos;
-            var tree_size = 0: uint(64);
+                                        var N_l = size;
+                                        var qtd_solucoes_thread = 0: uint(64);
+                                        var depthGlobal = depthPreFixos;
+                                        var tree_size = 0: uint(64);
 
-            for i in 0..<N_l do  // what happens if I use promotion here?
-              board[i] = _EMPTY_;
+                                        for i in 0..<N_l do  // what happens if I use promotion here?
+                                                board[i] = _EMPTY_;
 
-            flag = root_prefixes[idx:uint(64)].control;
+                                        flag = root_prefixes[idx:uint(64)].control;
 
-            for i in 0..<depthGlobal do
-              board[i] = root_prefixes[idx:uint(64)].board[i];
+                                        for i in 0..<depthGlobal do
+                                                board[i] = root_prefixes[idx:uint(64)].board[i];
 
-            depth=depthGlobal;
+                                        depth=depthGlobal;
 
-            do{
-              board[depth] += 1;
-              bit_test = 0;
-              bit_test |= 1<<board[depth];
+                                        do{
+                                                board[depth] += 1;
+                                                bit_test = 0;
+                                                bit_test |= 1<<board[depth];
 
-              if(board[depth] == N_l){
-                board[depth] = _EMPTY_;
-                //if(block_ub > upper)   block_ub = upper;
-              }else if (!(flag &  bit_test ) && GPU_queens_stillLegal(board, depth)){
+                                                if(board[depth] == N_l){
+                                                        board[depth] = _EMPTY_;
+                                                        //if(block_ub > upper)   block_ub = upper;
+                                                }else if (!(flag &  bit_test ) && GPU_queens_stillLegal(board, depth)){
 
-                tree_size += 1;
-                flag |= (1<<board[depth]);
+                                                        tree_size += 1;
+                                                        flag |= (1<<board[depth]);
 
-                depth += 1;
+                                                        depth += 1;
 
-                if (depth == N_l) { //sol
-                  qtd_solucoes_thread += 1;
-                }else continue;
-              }else continue;
+                                                        if (depth == N_l) { //sol
+                                                                qtd_solucoes_thread += 1;
+                                                        }else continue;
+                                                }else continue;
 
-              depth -= 1;
-              flag &= ~(1<<board[depth]);
+                                                depth -= 1;
+                                                flag &= ~(1<<board[depth]);
 
-            }while(depth >= depthGlobal); //FIM DO DFS_BNB
+                                        }while(depth >= depthGlobal); //FIM DO DFS_BNB
 
-            /*writeln("Sols: ", qtd_solucoes_thread);*/
-            sols[idx] = qtd_solucoes_thread;
-            vector_of_tree_size[idx] = tree_size;
-          }
+                                        /*writeln("Sols: ", qtd_solucoes_thread);*/
+                                        sols[idx] = qtd_solucoes_thread;
+                                        vector_of_tree_size[idx] = tree_size;
+                                }
 
-          sols_h = sols;
-          vector_of_tree_size_h = vector_of_tree_size;
+                                sols_h = sols;
+                                vector_of_tree_size_h = vector_of_tree_size;
+                        }
+                }//end of gpu search
+
+                stopVerboseGpu();
+
+                var redTree = (+ reduce vector_of_tree_size_h):uint(64);
+                var redSol  = (+ reduce sols_h):uint(64);
+
+                return ((redSol,redTree)+metrics);
         }
-    }//end of gpu search
 
-    stopVerboseGpu();
+        proc  GPU_queens_stillLegal(board, r) {
+                var safe = true;
+                var i: int;
+                var ld: int;
+                var rd: int;
 
-		var redTree = (+ reduce vector_of_tree_size_h):uint(64);
-		var redSol  = (+ reduce sols_h):uint(64);
+                // Check vertical
+                for i in 0..<r do
+                        if (board[i] == board[r]) then safe = false;
 
-		return ((redSol,redTree)+metrics);
-	}
-
-  proc  GPU_queens_stillLegal(board, r) {
-    var safe = true;
-    var i: int;
-    var ld: int;
-    var rd: int;
-
-    // Check vertical
-    for i in 0..<r do
-      if (board[i] == board[r]) then safe = false;
-
-    // Check diagonals
-    ld = board[r];  //left diagonal columns
-    rd = board[r];  // right diagonal columns
-    for i in 0..<r by -1 {
-      ld -= 1;
-      rd += 1;
-      if (board[i] == ld || board[i] == rd) then safe = false;
-    }
-    return safe;
-  }
+                // Check diagonals
+                ld = board[r];  //left diagonal columns
+                rd = board[r];  // right diagonal columns
+                for i in 0..<r by -1 {
+                        ld -= 1;
+                        rd += 1;
+                        if (board[i] == ld || board[i] == rd) then safe = false;
+                }
+                return safe;
+        }
 }

--- a/other_codes/chplGPU/modules/queens_GPU_single_locale.chpl
+++ b/other_codes/chplGPU/modules/queens_GPU_single_locale.chpl
@@ -20,7 +20,7 @@ module queens_GPU_single_locale{
 		var initial_num_prefixes : uint(64);
 		var initial_tree_size : uint(64) = 0;
 
-		var initial, final: Timer;
+		var initial, final: stopwatch;
 
 		//search metrics
 		var metrics: (uint(64),uint(64)) = (0:uint(64),0:uint(64));


### PR DESCRIPTION
Prepare for 2 deprecations:

- `GPUDiagnostics` and the functions within use the newly agreed upon convention to not capitalize the letters after the first one in an abbreviation. So `GpuDiagnostics` is the new module name. Note that we still fully capitalize if the name is just the abbreviation. So, the `GPU` module follows convention.
- `Timer` type has been deprecated in favor of `stopwatch`.

While there, this also fixes indentation in a file caused by me going against 8-space indentation of the original code when I first introduced it. Sorry!