### PR TITLE
Compilation Fix (Minor Type Mismatch)

### DIFF
--- a/modules/queens_tree_exploration.chpl
+++ b/modules/queens_tree_exploration.chpl
@@ -11,7 +11,7 @@ module queens_tree_exploration{
 
         var bit_test : uint(32) = 0;
         var control: uint(32) = 0;
-        var board: [0..MAX] int(8) = __EMPTY__;
+        var board: [0..MAX] uint(8) = __EMPTY__;
         var depth: int(32); //needs to be int because -1 is the break condition
         var number_sols: uint(64) = 0;
         var tree_size: uint(64) = 0;


### PR DESCRIPTION
Ran into this with Chapel 2.9 when trying out the single-locale no-GPU setting. Without this fix, later in the code (line 26) it raises an error saying "Cannot assign to int(8) from uint(8)". As best I can tell, it's just a minor typo that's getting caught now because more stringent error checking got added to mainline Chapel at some point.